### PR TITLE
jquery-bridget dependency fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,12 @@ An [AngularJS](http://angularjs.org/) directive to work with David Desandro's [P
 
 ## Usage
 
-1. `bower install --save angular-packery`
+1. `bower install --save git@github.com:htapal/angular-packery.git`
 2. Add `wu.packery` to your application's module dependencies.
 2. Include dependencies in your HTML.
 3. Use the `packery` directive.
 
 ## Example
-
-See the [homepage](http://passy.github.io/angular-packery) for a live example.
 
 ```html
 <div packery>

--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,8 @@
     "package.json"
   ],
   "dependencies": {
-    "packery": "~1.2.4",
+    "jquery-bridget": "~1.1.0",
+    "packery": "~1.3.2",
     "angular": "~1.2.0",
     "jquery": "~2.1.0",
     "imagesloaded": "~3.1.0"


### PR DESCRIPTION
angular-packery doesn't work without jquery-bridget on the page. I had no way of knowing this without doing some backtracking through the code. This fix to bower.json will resolve the issue for future bower users.

It doesn't look like you edited the README very carefully when adapting angular-masonry, so I went ahead and made a couple of updates there as well.
